### PR TITLE
fix crash on navigations

### DIFF
--- a/android/src/main/java/com/jackappdev/flutteriap/FlutterIapPlugin.java
+++ b/android/src/main/java/com/jackappdev/flutteriap/FlutterIapPlugin.java
@@ -67,7 +67,10 @@ public class FlutterIapPlugin implements MethodCallHandler {
 
             @Override
             public void onActivityDestroyed(Activity activity) {
-                billingManager.destroy();
+                if(billingManager != null) {
+                    billingManager.destroy();
+                    billingManager = null;
+                }
             }
         });
     }


### PR DESCRIPTION
This plugin is currently crashing with other plugins which starts another activity. The activity callbacks is executed for every Activities in the Application. This PR fixes this.