### PR TITLE
Improve Android product & inventory retrieval

### DIFF
--- a/android/src/main/java/com/jackappdev/flutteriap/BillingManager.java
+++ b/android/src/main/java/com/jackappdev/flutteriap/BillingManager.java
@@ -168,8 +168,9 @@ public class BillingManager implements PurchasesUpdatedListener {
         }
     }
 
-    public void querySkuDetailsAsync(@SkuType final String itemType, final List<String> skuList,
-                                     final SkuDetailsResponseListener listener) {
+    public void querySkuDetailsAsync(@SkuType final String itemType, final List<String> skuList) {
+        Log.d(TAG, "Querying SKU details.");
+
         // Creating a runnable from the request to use it inside our connection retry policy below
         Runnable queryRequest = new Runnable() {
             @Override
@@ -182,7 +183,11 @@ public class BillingManager implements PurchasesUpdatedListener {
                             @Override
                             public void onSkuDetailsResponse(int responseCode,
                                                              List<SkuDetails> skuDetailsList) {
-                                listener.onSkuDetailsResponse(responseCode, skuDetailsList);
+                                Log.d(TAG, "Received SKU details.");
+                                if (mSkuDetailsResponseListener != null) {
+                                    mSkuDetailsResponseListener
+                                        .onSkuDetailsResponse(responseCode, skuDetailsList);
+                                }
                             }
                         });
             }

--- a/lib/flutter_iap.dart
+++ b/lib/flutter_iap.dart
@@ -6,6 +6,15 @@ import 'package:flutter/services.dart';
 class FlutterIap {
   static const MethodChannel _channel = const MethodChannel('flutter_iap');
 
+  /// Retrieve a list of SKUs which have been purchased previously.
+  static Future<List<String>> fetchInventory() async {
+    String result = await _channel.invokeMethod("inventory");
+    Map<String, dynamic> map = json.decode(result);
+
+    List<dynamic> dynamicList = map["skus"];
+    return Future.value(dynamicList.map<String>((f) => f.toString()).toList());
+  }
+
   static Future<IAPResponse> fetchProducts(List<String> ids) async {
     String result = await _channel.invokeMethod("fetch", ids);
     return stringToResponse(result);


### PR DESCRIPTION
- Only submit requests to the Billing engine when the initialization is done
- Re-Create the billing manager for each interaction to avoid overlaps
- Add a new method to retrieve the list of SKUs a user has currently purchased (Android only, for the moment)

This should also fix https://github.com/JackAppDev/flutter_iap/issues/18

Currently, the `fetchInventory` does not retrieve active subscriptions, and does not work on iOS. I can work on this in about 2 months. 