### PR TITLE
Attempt to fix multiple item fetchProducts

### DIFF
--- a/ios/Classes/SwiftFlutterIapPlugin.swift
+++ b/ios/Classes/SwiftFlutterIapPlugin.swift
@@ -98,9 +98,8 @@ extension IAPHandler: SKProductsRequestDelegate, SKPaymentTransactionObserver {
       for product in response.products {
         if result.count > 1{
             result.append(",")
-        }else{
-            result.append("\(jsonFromProduct(product: product))")
         }
+        result.append("\(jsonFromProduct(product: product))")
       }
     }
     result.append("]")


### PR DESCRIPTION
The "else" causes the JSON builder to put only a comma for multiple items instead of the items themselves