### PR TITLE
Fixes issue 36 and includes other Android & generic fixes.

### DIFF
--- a/android/src/main/java/com/jackappdev/flutteriap/BillingManager.java
+++ b/android/src/main/java/com/jackappdev/flutteriap/BillingManager.java
@@ -109,9 +109,6 @@ public class BillingManager implements PurchasesUpdatedListener {
         if (mBillingUpdatesListener != null) {
           mBillingUpdatesListener.onBillingClientSetupFinished();
         }
-        // IAB is fully set up. Now, let's get an inventory of stuff we own.
-        Log.d(TAG, "Setup successful. Querying inventory.");
-        queryPurchases();
       }
     });
   }
@@ -145,14 +142,14 @@ public class BillingManager implements PurchasesUpdatedListener {
   /**
    * Start a purchase or subscription replace flow
    */
-  public void initiatePurchaseFlow(final String skuId, final ArrayList<String> oldSkus,
+  public void initiatePurchaseFlow(final String skuId, final String oldSku,
       final @SkuType String billingType) {
     Runnable purchaseFlowRequest = new Runnable() {
       @Override
       public void run() {
-        Log.d(TAG, "Launching in-app purchase flow. Replace old SKU? " + (oldSkus != null));
+        Log.d(TAG, "Launching in-app purchase flow. Replace old SKU? " + (oldSku != null));
         BillingFlowParams purchaseParams = BillingFlowParams.newBuilder().setSku(skuId).setType(billingType)
-            .setOldSkus(oldSkus).build();
+            .setOldSku(oldSku).build();
         mBillingClient.launchBillingFlow(mActivity, purchaseParams);
       }
     };

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.1.4'
     }
 }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -19,6 +19,7 @@ class _MyAppState extends State<MyApp> {
   }
 
   init() async {
+    // Android testers: You can use "android.test.purchased" to simulate a successful flow.
     List<String> productIds = ["com.example.testiap"];
 
     IAPResponse response = await FlutterIap.fetchProducts(productIds);
@@ -68,7 +69,7 @@ class _MyAppState extends State<MyApp> {
             children: <Widget>[
               new Text(
                 _productIds.isNotEmpty
-                    ? "Fetched: $_productIds"
+                    ? "Available Products to purchase: $_productIds"
                     : "Not working?\n"
                     "Check that you set up in app purchases in\n"
                     "iTunes Connect / Google Play Console",
@@ -84,8 +85,17 @@ class _MyAppState extends State<MyApp> {
         floatingActionButton: nextPurchase != null
             ? new FloatingActionButton(
                 child: new Icon(Icons.monetization_on),
-                onPressed: () {
-                  FlutterIap.buy(nextPurchase);
+                onPressed: () async {
+                  IAPResponse response = await FlutterIap.buy(nextPurchase);
+                  if (response.purchases != null) {
+                    List<String> purchasedIds = response.purchases
+                        .map((IAPPurchase purchase) => purchase.productIdentifier)
+                        .toList();
+
+                    setState(() {
+                      _alreadyPurchased = purchasedIds;
+                    });
+                  }
                 },
               )
             : new Container(),


### PR DESCRIPTION
Full list of changes in this PR:

Android:
- Plugin would fetch all previous purchases every time the BillingClient has been instantiated. This is now removed and users have to explicitly use API calls to fetch the inventory. This prevents various internal state issues in the Android plugin (e.g. a successful purchase also returns a list of purchases). This was the root cause for issue #36.
- Remove usage of a deprecated API in the BillingFlowParams builder
- The IAP Responses did not contain valid JSON and therefore sometimes didn't make it over to the client. The "originalJson" for once should be encoded (or added as a proper JSON tree) and then always be compliant to the IAPResponse model.
- Once a IAP was purchased, the plugin would simply consume the first IAP product it would retrieve from Google. However, the API might return a list of ALL previously purchased items. The plugin will now search for the same SKU and consume only that one.
- "fetchInventory" and "buy" APIs will now use the "purchases" fields in the IAPResponse model. (they are, by all means, purchases). This might break some users Apps.
- Gradle plugin updated

Example:
- Example code now awaits for purchase completion and then updates the list.